### PR TITLE
Fix forum permissions and settings deletion on uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## OUGC Unquote First Post
-Disables the quoting of the first post of any thread.
+Disable the quote button for threads or all posts.
 
 ***
 

--- a/Upload/inc/languages/espanol/admin/ougc_unquotefirstpost.lang.php
+++ b/Upload/inc/languages/espanol/admin/ougc_unquotefirstpost.lang.php
@@ -29,7 +29,7 @@
  
 // Plugin API
 $l['ougc_unquotefirstpost'] = 'OUGC Unquote First Post';
-$l['ougc_unquotefirstpost_desc'] = 'Desabilita la opcion de citar los temas, mensajes, o ambos.';
+$l['ougc_unquotefirstpost_desc'] = 'Deshabilita la opción de citar los temas, mensajes, o ambos.';
 
 // PluginLibrary
 $l['ougc_unquotefirstpost_pluginlibrary_error'] = 'Este plugin require <a href="{1}">PluginLibrary</a> version {2} o mas. Por favor sube los arhivos necesarios.';

--- a/Upload/inc/plugins/ougc_unquotefirstpost.php
+++ b/Upload/inc/plugins/ougc_unquotefirstpost.php
@@ -147,7 +147,7 @@ function ougc_unquotefirstpost_uninstall()
 	global $cache, $PL;
 
 	// Delete settings
-	$PL->settings_delete('ougc_customrep');
+	$PL->settings_delete('ougc_unquotefirstpost');
 
 	// Remove version code from cache
 	$plugins = (array)$cache->read('ougc_plugins');

--- a/Upload/inc/plugins/ougc_unquotefirstpost.php
+++ b/Upload/inc/plugins/ougc_unquotefirstpost.php
@@ -39,6 +39,9 @@ if(!defined('IN_ADMINCP'))
 	$plugins->add_hook('xmlhttp_get_multiquoted_intermediate', 'ougc_unquotefirstpost');
 }
 
+// PLUGINLIBRARY
+defined('PLUGINLIBRARY') or define('PLUGINLIBRARY', MYBB_ROOT.'inc/plugins/pluginlibrary.php');
+
 // Plugin API
 function ougc_unquotefirstpost_info()
 {


### PR DESCRIPTION
This pull request updates the OUGC Unquote First Post plugin to improve its logic for disabling the quote button, enhance language accuracy, and fix a settings deletion bug. The main changes include a more flexible approach to determining which posts or forums are affected, a corrected settings key during uninstallation, and minor language and documentation improvements.